### PR TITLE
Private Routes Implemented. User Model Now Includes userName

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -6,6 +6,7 @@ import jwt_decode from "jwt-decode";
 import setAuthToken from "../utils/setAuthToken";
 import { setCurrentUser, logoutUser } from "../redux/actions/authActions";
 
+import PrivateRoute from "../components/common/PrivateRoute";
 import store from "../redux/store";
 import history from "../history";
 
@@ -40,7 +41,7 @@ const App = () => {
                 <Route path="/" exact component={Landing} />
                 <Route path="/about" exact component={About} />
                 <Route path="/course" exact component={Course} />
-                <Route path="/profile" exact component={Profile} />
+                <PrivateRoute path="/profile" exact component={Profile} />
                 <Route path="/login" exact component={Login} />
                 <Route path="/register" exact component={Register} />
               </Switch>

--- a/client/src/components/common/PrivateRoute.js
+++ b/client/src/components/common/PrivateRoute.js
@@ -1,0 +1,27 @@
+import React from "react";
+import { Route, Redirect } from "react-router-dom";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
+
+const PrivateRoute = ({ component: Component, auth, ...rest }) => (
+  <Route
+    {...rest}
+    render={props =>
+      auth.isAuthenticated === true ? (
+        <Component {...props} />
+      ) : (
+        <Redirect to="/login" />
+      )
+    }
+  />
+);
+
+PrivateRoute.propTypes = {
+  auth: PropTypes.object.isRequired
+};
+
+const mapStateToProps = state => ({
+  auth: state.auth
+});
+
+export default connect(mapStateToProps)(PrivateRoute);

--- a/client/src/components/layout/Footer.js
+++ b/client/src/components/layout/Footer.js
@@ -4,7 +4,9 @@ const Footer = props => {
   return (
     <div>
       <footer className="sticky-bottom" style={styles.footer}>
-        <p style={styles.footercolor}>&copy; TeleQuest {new Date().getFullYear()}</p>
+        <p style={styles.footercolor}>
+          &copy; TeleQuest {new Date().getFullYear()}
+        </p>
       </footer>
     </div>
   );
@@ -14,16 +16,16 @@ export default Footer;
 
 const styles = {
   footer: {
-    width: '100%',
+    width: "100%",
     height: 50,
-    backgroundColor: '#1c1c1c',
-    justifyContent: 'center',
-    alignItems: 'center',
-    position: 'absolute',
+    backgroundColor: "#1c1c1c",
+    justifyContent: "center",
+    alignItems: "center",
+    position: "absolute",
     bottom: 0
   },
 
-  footercolor:{
-    color: '#ff8738'
+  footercolor: {
+    color: "#ff8738"
   }
 };

--- a/client/src/components/layout/Navbar.js
+++ b/client/src/components/layout/Navbar.js
@@ -11,8 +11,7 @@ const styles = {
     height: "30px"
   },
   Avatar: {
-    width: "25px",
-    marginRight: "5px"
+    width: "25px"
   }
 };
 
@@ -30,6 +29,13 @@ class Navbar extends Component {
         <li className="nav-item">
           <Link className="nav-link" to="/profile">
             My Profile
+            <img
+              className="rounded-circle ml-2"
+              src={user.avatar}
+              alt={user.userName}
+              style={styles.Avatar}
+              title="You must have a Gravatar connected to your email to display an image"
+            />
           </Link>
         </li>
         <li className="nav-item">
@@ -38,14 +44,8 @@ class Navbar extends Component {
             onClick={this.onLogoutClick.bind(this)}
             className="nav-link"
           >
-            <img
-              className="rounded-circle mr-2"
-              src={user.avatar}
-              alt={user.firstName + " " + user.lastName}
-              style={styles.Avatar}
-              title="You must have a Gravatar connected to your email to display an image"
-            />
             Logout
+            <i className="fas fa-sign-out-alt ml-2" />
           </Link>
         </li>
       </ul>

--- a/client/src/components/profile/Profile.js
+++ b/client/src/components/profile/Profile.js
@@ -1,15 +1,27 @@
 import React from "react";
+import { connect } from "react-redux";
+import PropTypes from "prop-types";
 
 class Profile extends React.Component {
   state = {};
 
   render() {
+    const { userName } = this.props.auth.user;
+
     return (
       <div>
-        <h1>Profile</h1>
+        <h1>Hello {userName}</h1>
       </div>
     );
   }
 }
 
-export default Profile;
+Profile.propTypes = {
+  auth: PropTypes.object.isRequired
+};
+
+const mapStateToProps = state => ({
+  auth: state.auth
+});
+
+export default connect(mapStateToProps)(Profile);

--- a/client/src/redux/store.js
+++ b/client/src/redux/store.js
@@ -4,13 +4,17 @@ import reducers from "./reducers";
 
 /*
  * Integrates React Developer Tools
- * Install: https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi
+ * Install React DevTools: https://github.com/facebook/react-devtools
+ * Install Redux DevTools: https://github.com/zalmoxisus/redux-devtools-extension
  */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+const initialState = {};
+const middleware = [reduxThunk];
 
 const store = createStore(
   reducers,
-  composeEnhancers(applyMiddleware(reduxThunk))
+  initialState,
+  composeEnhancers(applyMiddleware(...middleware))
 );
 
 export default store;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -11,6 +11,10 @@ const UserSchema = new Schema({
     type: String,
     required: true
   },
+  userName: {
+    type: String,
+    required: true
+  },
   email: {
     type: String,
     required: true,

--- a/server/routes/api/v1/users.js
+++ b/server/routes/api/v1/users.js
@@ -48,6 +48,7 @@ router.post("/register", (req, res) => {
       const newUser = new User({
         firstName: body.firstName,
         lastName: body.lastName,
+        userName: `${body.firstName} ${body.lastName}`,
         email: body.email,
         avatar,
         password: body.password
@@ -96,6 +97,7 @@ router.post("/login", (req, res) => {
           id: user.id,
           firstName: user.firstName,
           lastName: user.lastName,
+          userName: user.userName,
           avatar: user.avatar
         };
 
@@ -129,6 +131,7 @@ router.get(
       id: req.user.id,
       firstName: req.user.firstName,
       lastName: req.user.lastName,
+      userName: req.user.userName,
       email: req.user.email
     });
   }


### PR DESCRIPTION
Team,

After reviewing our github resources & searching the online community ... it seems like react does not have a way to protect routes on the client. There is a workaround that works perfectly in our project from Brad, so I used it. I tested this on the profile route and it works like a charm.

I also modified the user model on the server to include a userName field, since I realized interpolating the first and last names would be done so often, it was better to consolidate that logic into one place and have the option open to allow users to have their own usernames in the future if we want. For now their usernames will be their firstName and their lastName.